### PR TITLE
ci: add format/lint jobs and align PR checks across all repos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## What
+
+<!-- One sentence: what does this PR do? -->
+
+## Why
+
+<!-- Why is this change needed? Link issues if applicable. -->
+
+## Changes
+
+<!-- Bullet list of what changed. Be specific: file names, before/after values. -->
+
+-
+
+## Test Plan
+
+<!-- How was this verified? Check all that apply. -->
+
+- [ ] Unit tests pass (`make test` / `npm run test:unit` / `dotnet test` / `poetry run pytest`)
+- [ ] Linter / formatter clean (`make fmt-check` / `npm run lint` / `dotnet format --verify-no-changes`)
+- [ ] Manual smoke test against local `docker compose up`
+- [ ] Integration tests pass (if DB available)
+- [ ] No new high-severity vulnerabilities (`npm audit --audit-level=high` / `trivy`)
+
+## Checklist
+
+- [ ] Commit messages follow Conventional Commits (`type(scope): description`)
+- [ ] No debug output, commented-out code, or `TODO`s left behind
+- [ ] Equivalent change applied to all relevant repos (if cross-repo feature)
+- [ ] Docs / README updated if behaviour or setup changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,16 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
       
@@ -35,10 +35,10 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
       
@@ -59,10 +59,10 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
       
@@ -84,10 +84,10 @@ jobs:
       matrix:
         python-version: ['3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
       
@@ -103,14 +103,14 @@ jobs:
         run: poetry run pytest tests/ --cov=app --cov-report=xml --cov-report=term-missing
       
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: matrix.python-version == '3.12'
         with:
           name: coverage
           path: coverage.xml
       
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         if: matrix.python-version == '3.12'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -118,7 +118,7 @@ jobs:
           fail_ci_if_error: false
       
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19 # v4
         if: matrix.python-version == '3.12'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -132,13 +132,13 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       
       - name: Build Docker image for PR validation
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: false
@@ -155,7 +155,7 @@ jobs:
           docker inspect otel-example-python:pr-${{ github.event.pull_request.number }}
       
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           image-ref: otel-example-python:pr-${{ github.event.pull_request.number }}
           format: 'sarif'
@@ -164,7 +164,7 @@ jobs:
           TRIVY_SKIP_VERSION_CHECK: true
       
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
           fail_ci_if_error: false
       
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19 # v4
+        uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5
         if: matrix.python-version == '3.12'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,23 +23,23 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -70,7 +70,7 @@ jobs:
           provenance: true
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
         with:
           image-ref: ${{ env.IMAGE_NAME }}:latest
           format: 'sarif'
@@ -79,20 +79,20 @@ jobs:
           TRIVY_SKIP_VERSION_CHECK: true
 
       - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11 # v0
         with:
           image: ${{ env.IMAGE_NAME }}:latest
           format: spdx-json
           output-file: sbom.spdx.json
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: sbom
           path: sbom.spdx.json

--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -3,7 +3,7 @@
 import logging
 import sys
 
-from pythonjsonlogger.jsonlogger import JsonFormatter  # type: ignore[attr-defined]
+from pythonjsonlogger.json import JsonFormatter
 
 from app.config import get_settings
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 3%
+    patch:
+      default:
+        target: 90%

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,6 @@
 """Unit test configuration and shared fixtures."""
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Generator
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,7 +10,7 @@ from app.main import app
 
 
 @pytest.fixture(autouse=True)
-def override_get_db() -> AsyncGenerator[None, None]:  # type: ignore[misc]
+def override_get_db() -> Generator[None, None, None]:
     """Override the get_db dependency to prevent real DB connections in unit tests."""
     mock_session = MagicMock()
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,22 @@
+"""Unit test configuration and shared fixtures."""
+
+from collections.abc import AsyncGenerator
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.database import get_db
+from app.main import app
+
+
+@pytest.fixture(autouse=True)
+def override_get_db() -> AsyncGenerator[None, None]:  # type: ignore[misc]
+    """Override the get_db dependency to prevent real DB connections in unit tests."""
+    mock_session = MagicMock()
+
+    async def mock_get_db() -> AsyncGenerator[MagicMock, None]:
+        yield mock_session
+
+    app.dependency_overrides[get_db] = mock_get_db
+    yield
+    app.dependency_overrides.clear()

--- a/tests/unit/test_user_routes.py
+++ b/tests/unit/test_user_routes.py
@@ -82,7 +82,7 @@ class TestCreateUser:
             json={"name": "John Doe", "email": "invalid-email", "bio": "Engineer"},
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     def test_create_user_missing_name(self) -> None:
         """Test creating user without name."""
@@ -91,7 +91,7 @@ class TestCreateUser:
             json={"email": "john@example.com", "bio": "Engineer"},
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
 class TestGetUsers:


### PR DESCRIPTION
## What
Align CI pipeline structure across all 6 OTel repos.

## Changes
- Add concurrency block to cancel stale runs on new pushes
- Add format and lint jobs using each repo native tooling
- Gate test and build on format+lint passing
- Add PR-only docker-build job with Trivy vulnerability scan
- .NET: split docker-build (PR gate) from docker-publish (main-only push)