### PR TITLE
docs: standardize README badges across all repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![CI](https://img.shields.io/github/actions/workflow/status/devops-thiago/otel-example-python/ci.yml?branch=main&label=CI)](https://github.com/devops-thiago/otel-example-python/actions)
 [![Python Version](https://img.shields.io/badge/python-3.11%2B-blue?logo=python)](https://www.python.org)
-[![FastAPI](https://img.shields.io/badge/FastAPI-0.115%2B-009688?logo=fastapi)](https://fastapi.tiangolo.com)
+[![FastAPI](https://img.shields.io/badge/FastAPI-0.131%2B-009688?logo=fastapi)](https://fastapi.tiangolo.com)
 [![License](https://img.shields.io/github/license/devops-thiago/otel-example-python)](LICENSE)
 [![Codecov](https://img.shields.io/codecov/c/github/devops-thiago/otel-example-python?label=coverage)](https://app.codecov.io/gh/devops-thiago/otel-example-python)
 [![Sonar Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=devops-thiago_otel-example-python&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=devops-thiago_otel-example-python)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=devops-thiago_otel-example-python&metric=coverage)](https://sonarcloud.io/summary/new_code?id=devops-thiago_otel-example-python)
+[![Sonar Coverage](https://sonarcloud.io/api/project_badges/measure?project=devops-thiago_otel-example-python&metric=coverage)](https://sonarcloud.io/summary/new_code?id=devops-thiago_otel-example-python)
 [![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-enabled-blue?logo=opentelemetry)](https://opentelemetry.io)
 [![Docker](https://img.shields.io/badge/Docker-ready-blue?logo=docker)](https://www.docker.com)
 [![Docker Hub](https://img.shields.io/docker/v/thiagosg/otel-crud-api-python?logo=docker&label=Docker%20Hub)](https://hub.docker.com/r/thiagosg/otel-crud-api-python)


### PR DESCRIPTION
- Align badge order: CI → language → framework → license → Codecov → Sonar Quality Gate → Sonar Coverage → OTel → Docker → Docker Hub → Docker Pulls
- Rename SonarCloud coverage badge label to 'Sonar Coverage' for clarity (was 'Coverage', clashing with Codecov)
- Use shields.io github/actions/workflow for CI badges (consistent style and avoids encoding issues)
- Use shields.io github/license for license badges (dynamic, no hardcoded spdx text)
- Use shields.io codecov for coverage badges (consistent style)

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- Why is this change needed? Link issues if applicable. -->

## Changes

<!-- Bullet list of what changed. Be specific: file names, before/after values. -->

-

## Test Plan

<!-- How was this verified? Check all that apply. -->

- [ ] Unit tests pass (`make test` / `npm run test:unit` / `dotnet test` / `poetry run pytest`)
- [ ] Linter / formatter clean (`make fmt-check` / `npm run lint` / `dotnet format --verify-no-changes`)
- [ ] Manual smoke test against local `docker compose up`
- [ ] Integration tests pass (if DB available)
- [ ] No new high-severity vulnerabilities (`npm audit --audit-level=high` / `trivy`)

## Checklist

- [ ] Commit messages follow Conventional Commits (`type(scope): description`)
- [ ] No debug output, commented-out code, or `TODO`s left behind
- [ ] Equivalent change applied to all relevant repos (if cross-repo feature)
- [ ] Docs / README updated if behaviour or setup changed
