### PR TITLE
ci: replace deprecated sonarcloud-github-action with SHA-pinned sonarqube-scan-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,11 +118,12 @@ jobs:
           fail_ci_if_error: false
       
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
         if: matrix.python-version == '3.12'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
 
   docker-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why
Repo allowed-actions policy requires all actions pinned to a full-length commit SHA. The Sonar step used `SonarSource/sonarcloud-github-action` (deprecated), which is SHA-pinned but internally invokes `sonarqube-scan-action@v5.0.0` **by tag** — rejected by the policy, failing the Sonar job at 'Set up job'.

## What
- Swap the deprecated wrapper for `SonarSource/sonarqube-scan-action` pinned to SHA (v7.0.0).
- Add `SONAR_HOST_URL: https://sonarcloud.io` (matches otel-example-java).

🤖 Generated with [Claude Code](https://claude.com/claude-code)