### PR TITLE
fix(security): resolve CodeQL code-scanning alerts + harden container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Least-privilege default token for all jobs (CodeQL: missing-workflow-permissions).
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.14-slim AS deps
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -8,7 +9,8 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir poetry==1.8.3
+RUN pip install --no-cache-dir --upgrade pip setuptools && \
+    pip install --no-cache-dir poetry==1.8.3
 
 COPY pyproject.toml ./
 
@@ -53,6 +55,7 @@ LABEL org.opencontainers.image.title="OpenTelemetry Python CRUD API" \
       org.opencontainers.image.licenses="MIT"
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \

--- a/app/routes/health.py
+++ b/app/routes/health.py
@@ -42,12 +42,13 @@ async def ready(db: Annotated[AsyncSession, Depends(get_db)]) -> JSONResponse:
             content={"status": "ready", "database": "connected"},
         )
     except Exception as e:
+        # Log the detail server-side; do not leak exception text to the client
+        # (CodeQL: py/stack-trace-exposure).
         logger.error("Readiness check failed: %s", str(e))
         return JSONResponse(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             content={
                 "status": "not ready",
                 "database": "disconnected",
-                "error": str(e),
             },
         )


### PR DESCRIPTION
## What

Addresses the open **code scanning** alerts (https://github.com/devops-thiago/otel-example-python/security/code-scanning). These are SAST/image findings, separate from the dependency fixes in #51.

### CodeQL — all 5 medium alerts (fully fixed) ✅
| Alert | Location | Fix |
|-------|----------|-----|
| `py/stack-trace-exposure` | `app/routes/health.py` | `/ready` returned the raw exception text to the client on DB failure — now logged server-side only, removed from the response body |
| `actions/missing-workflow-permissions` ×4 | `.github/workflows/ci.yml` | added top-level least-privilege `permissions: contents: read` (read-only default token for all jobs) |

### Trivy (container image) — hardening
- Added `apt-get upgrade -y` to the deps **and** final stages, and upgraded `pip`/`setuptools`, so the runtime image picks up available OS/pip security patches.

> **Honest scope note:** the bulk of the Trivy alerts are **base-image (Debian 13) OS packages** that are either **won't-fix** by Debian or have **no fix available upstream** — e.g. the 2 `high` ones are glibc `CVE-2026-0861` with an empty "Fixed Version". Those cannot be cleared by a Dockerfile change; only a base-image strategy change (e.g. distroless / Wolfi/Chainguard) would meaningfully reduce them. Happy to do that as a follow-up if you want.

## Verification
- App tests: **26 passed**
- `ruff` / `black` / `mypy`: clean
- Dockerfile: valid (continuation syntax; the IDE "Unknown instruction" warning is a known language-server false positive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)